### PR TITLE
Option for manually resolving destination paths.

### DIFF
--- a/hash-src.js
+++ b/hash-src.js
@@ -68,6 +68,11 @@ function analyze(match)
     };
 }
 
+function destination_path(build_dir, link)
+{
+  return p.join(build_dir, link);
+}
+
 p = fs_helper.p;
 
 module.exports = function hash_src(options)
@@ -93,6 +98,9 @@ module.exports = function hash_src(options)
     if (!options.analyze) {
         options.analyze = analyze;
     }
+    if (!options.destination_path) {
+        options.destination_path = destination_path;
+    }
     if (typeof options.query_name === "undefined") {
         options.query_name = "cbh"; /// "cache busting hash"
     }
@@ -115,8 +123,8 @@ module.exports = function hash_src(options)
                 return next();
             }
             
-            full_path = p.join(options.build_dir, link);
             
+            full_path = options.destination_path(options.build_dir, link);
             fs_helper.fs.exists(full_path, function onres(exists)
             {
                 if (!exists) {


### PR DESCRIPTION
## Use case.

Build dir

```
/dist/js/*.js
/dist/css/*.css
/dist/index.html
/dist/es/index.html
/dist/ru/index.html
/dist/it/index.html
```

Paths in index.html

```
src="/slug/js/*.js"
href="/slug/css/*.css"
```

---

```
require("path").join("./dist", "/slug/css/*.css")
```

turn into

```
dist/slug/css/*.css.
```

But real path is:

```
/dist/css/*.css
```
