### PR TITLE
Fix URI malformed issue for links with percent symbol

### DIFF
--- a/hash-src.js
+++ b/hash-src.js
@@ -31,7 +31,11 @@ function match_all(regex, str)
 
 function clean_link(link, base)
 {
-    link = decodeURI(String(link));
+    try {
+        link = decodeURI(String(link));
+    } catch (err) {
+        // do nothing
+    }
     
     /// Is it relative
     if (base && link[0] !== "/" && !is_abs_link(link)) {


### PR DESCRIPTION
Fix URI malformed issue for links with percent symbol
https://github.com/nmrugg/gulp-hash-src/issues/4
http://stackoverflow.com/questions/9064536/javascript-decodeuricomponent-malformed-uri-exception
